### PR TITLE
Parallelization of scoring, 2nd attempt

### DIFF
--- a/javolver/Javolver.java
+++ b/javolver/Javolver.java
@@ -2,9 +2,6 @@ package javolver;
 
 import java.util.ArrayList;
 
-import javolver.JavolverBreed.BreedMethod;
-
-
 
 /**
  * Javolver is a simple engine that processes a pool of individuals using genetic selection.
@@ -100,7 +97,11 @@ public class Javolver {
 	 */
 	public void doOneCycle()
 	{
-		scoreGenes(genePool);
+		if (config.parallelScoring) {
+			scoreGenesParallel(genePool);
+		} else {
+			scoreGenes(genePool);
+		}
 		
 		JavolverRanking.calculateFitnessRank(genePool);
 		JavolverRanking.calculateDiversityRank(genePool);
@@ -162,6 +163,10 @@ public class Javolver {
 		{
 			gene.getScore();
 		}
+	}
+	
+	public void scoreGenesParallel(ArrayList<Individual> pool) {
+		pool.parallelStream().unordered().forEach(Individual::getScore);
 	}
 	
 	

--- a/javolver/JavolverConfig.java
+++ b/javolver/JavolverConfig.java
@@ -42,7 +42,12 @@ public class JavolverConfig {
 	public double mutationAmount = 0.10;
 	public int mutationCount = 2;
 	public boolean allowSwapMutation = false;
-	
-	
+
+	/**
+	 * Use multi-threading for the scoring process.
+	 * Set this to true if your {@link Individual#calculateScore()} method
+	 * is expensive to run and may benefit from parallelization.
+	 */
+	public boolean parallelScoring = false;
 	
 }


### PR DESCRIPTION
*Right upfront I'm sorry, this text got a lot longer than I anticipated*

I added the config for the parallel scoring like we discussed.

I'm simply using Java 8 Streams for it now, which makes it a neat one-liner.
Here's an explanation in case you don't yet know how Streams work (and anyone who may read this later and does not know about them):

```Java
pool.parallelStream().unordered().forEach(Individual::getScore);
```

* **pool.parallelStream()** - creating a stream containing all Individuals from the pool that can be processed in parallel
* **.unordered()** - Telling Java that we don't care about the order of the elements in the stream. This is supposed to open up a bit more room for parallelization
* **.forEach( ... )** - execute the given action for each element in the stream
* **Individual::getScore** - a method reference to `individual.getScore()`. This is the action that will be executed for each element. Each element of the stream is of the class Individual, and the `getScore()` method will be called for every one.

**_One more thing:_** I noticed a bug (?) when trying the parallelization with the Tree test. When I first tried activating the parallelization, it did not seem to change a thing. My CPU cores were still bored. I added some time-measurements, and the `doOneCycle()` method only took 1-2ms regardless of the tree complexities and number of individuals. Turns out that this is because the pool is reset with the new individuals at the end of the cycle. That is because the call to `findBestScoringIndividual()` at the start of the Tree test for-loop will trigger the score calculation for each individual before the `doOneCycle()`. This completely circumvents the new parallelization of the score calculation. When I commented out the call to `findBestScoringIndividual()` and tried again, the time measurements were acurate and all CPU cores were churning away at 100% load. :)

To fix the score calculation trigger issue I would suggest to simply do the mutations and creation of a new pool `doOneCycle` before the scoring instead of after it. This would immediately resolve all potential issues of score calculation being triggered outside of `doOneCycle`.


Some time measurements with a population of 100 trees:
<table>
 <tr>
  <th>Iteration</th>
  <th>Parallel</th>
  <th>doOneCycle( )</th>
 </tr>
 <tr>
  <td>5</td>
  <td>no</td>
  <td>15 ms</td>
 </tr>
 <tr>
  <td>5</td>
  <td>yes</td>
  <td>24 ms</td>
 </tr>
 <tr>
  <td>10</td>
  <td>no</td>
  <td>539 ms</td>
 </tr>
 <tr>
  <td>10</td>
  <td>yes</td>
  <td>57 ms</td>
 </tr>
 <tr>
  <td>15</td>
  <td>no</td>
  <td>1343 ms</td>
 </tr>
 <tr>
  <td>15</td>
  <td>yes</td>
  <td>135 ms</td>
 </tr>
 <tr>
  <td>20</td>
  <td>no</td>
  <td>2069 ms</td>
 </tr>
 <tr>
  <td>20</td>
  <td>yes</td>
  <td>315 ms</td>
 </tr>
</table>
Those measurements were only taken from a single run, so they are not a definitive benchmark, but I think they already give a good impression of the improvement. :)